### PR TITLE
fix first doc comment paragraph too long

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,9 +12,7 @@ pub mod stringify;
 
 use serde::{Deserialize, Serialize};
 
-/// Wrap the @context property to support serialization/deserialization of an ordered
-/// set composed of any combination of URLs and/or objects, each processable as a
-/// [JSON-LD Context](https://www.w3.org/TR/json-ld11/#the-context).
+/// `Kind` allows serde to serialize/deserialize a string or an object.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum Kind<T> {

--- a/crates/datasec/src/jose/jwe.rs
+++ b/crates/datasec/src/jose/jwe.rs
@@ -188,10 +188,11 @@ pub async fn decrypt<T: DeserializeOwned>(
 }
 
 /// In JWE JSON serialization, one or more of the JWE Protected Header, JWE Shared
-/// Unprotected Header, and JWE Per-Recipient Unprotected Header MUST be present. In
-/// this case, the members of the JOSE Header are the union of the members of the JWE
-/// Protected Header, JWE Shared Unprotected Header, and JWE Per-Recipient Unprotected
-/// Header values that are present.
+/// Unprotected Header, and JWE Per-Recipient Unprotected Header MUST be present.
+/// 
+/// In this case, the members of the JOSE Header are the union of the members of
+/// the JWE Protected Header, JWE Shared Unprotected Header, and JWE
+/// Per-Recipient Unprotected Header values that are present.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Jwe {
     /// JWE protected header.

--- a/crates/datasec/src/lib.rs
+++ b/crates/datasec/src/lib.rs
@@ -50,9 +50,11 @@ pub use crate::jose::jwk::PublicKeyJwk;
 pub use crate::jose::jwt::Jwt;
 
 /// The `SecOps` trait is used to provide methods needed for signing, encrypting,
-/// verifying, and decrypting data. Implementers of this trait are expected to
-/// provide the necessary cryptographic functionality to support Verifiable
-/// Credential issuance and Verifiable Presentation submissions.
+/// verifying, and decrypting data.
+/// 
+/// Implementers of this trait are expected to provide the necessary
+/// cryptographic functionality to support Verifiable Credential issuance and
+/// Verifiable Presentation submissions.
 pub trait SecOps: Send + Sync {
     /// Signer provides digital signing-related funtionality.
     /// The `identifier` parameter is one of `credential_issuer` or `verifier_id`.

--- a/crates/dif-exch/src/lib.rs
+++ b/crates/dif-exch/src/lib.rs
@@ -16,7 +16,9 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 /// Used to provide `serde`-compatible set of Claims  serialized as JSON (as
-/// [`serde_json::Value`]). Per the Presentation Exchange specification, this trait
+/// [`serde_json::Value`]).
+/// 
+/// Per the Presentation Exchange specification, this trait
 /// can be implemented for a variety of `Claim` formats.
 pub trait Claims {
     /// Serialize Claims as a JSON object.
@@ -102,6 +104,7 @@ pub struct InputDescriptor {
 
 /// A registered Claim Format Designation object (e.g., `jwt`, `jwt_vc`, `jwt_vp`,
 /// etc.) used to inform the Holder of a Claim format the Verifier can process.
+/// 
 /// A Format object MUST include one of the format-specific properties (i.e.,
 /// `alg`, `proof_type`) that specify which algorithms the Verifier supports for the
 /// format.

--- a/crates/openid/src/issuer.rs
+++ b/crates/openid/src/issuer.rs
@@ -296,6 +296,7 @@ pub struct PreAuthorizedCodeGrant {
 
 /// Specifies whether the Authorization Server expects presentation of a Transaction
 /// Code by the End-User along with the Token Request in a Pre-Authorized Code Flow.
+/// 
 /// If the Authorization Server does not expect a Transaction Code, this object is
 /// absent; this is the default.
 ///
@@ -675,8 +676,10 @@ pub enum TokenType {
 }
 
 /// Authorization Details object specifically for use in successful Access Token
-/// responses ([`TokenResponse`]). It wraps the `AuthorizationDetail` struct and adds
-/// `credential_identifiers` parameter for use in Credential requests.
+/// responses ([`TokenResponse`]).
+/// 
+/// It wraps the `AuthorizationDetail` struct and adds `credential_identifiers`
+/// parameter for use in Credential requests.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TokenAuthorizationDetail {
     /// Reuse (and flatten) the existing [`AuthorizationDetail`] object used in
@@ -874,11 +877,12 @@ pub struct CredentialResponseEncryption {
     pub enc: String,
 }
 
-/// The Credential Response can be Synchronous or Deferred. The Credential
-/// Issuer MAY be able to immediately issue a requested Credential. In other
-/// cases, the Credential Issuer MAY NOT be able to immediately issue a
-/// requested Credential and will instead return an `transaction_id` to be
-/// used later to retrieve a Credential when it is ready.
+/// The Credential Response can be Synchronous or Deferred.
+/// 
+/// The Credential Issuer MAY be able to immediately issue a requested
+/// Credential. In other cases, the Credential Issuer MAY NOT be able to
+/// immediately issue a requested Credential and will instead return a
+/// `transaction_id` to be used later to retrieve a Credential when it is ready.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CredentialResponse {
     /// The issued Credential. MUST be present when `transaction_id` is not
@@ -1199,8 +1203,10 @@ pub struct CredentialConfiguration {
 }
 
 /// `ProofTypesSupported` describes specifics of the key proof(s) that the Credential
-/// Issuer supports. This object contains a list of name/value pairs, where each name
-/// is a unique identifier of the supported proof type(s). Valid values are defined in
+/// Issuer supports.
+/// 
+/// This object contains a list of name/value pairs, where each name is a unique
+/// identifier of the supported proof type(s). Valid values are defined in
 /// Section 7.2.1, other values MAY be used. This identifier is also used by the Wallet
 /// in the Credential Request as defined in Section 7.2. The value in the name/value
 /// pair is an object that contains metadata about the key proof.

--- a/crates/openid/src/verifier.rs
+++ b/crates/openid/src/verifier.rs
@@ -107,9 +107,10 @@ pub struct CreateRequestResponse {
     pub request_uri: Option<String>,
 }
 
-/// The Authorization Request follows the definition given in [RFC6749]. The Verifier
-/// may send an Authorization Request as Request Object by value or by reference as
-/// defined in JWT-Secured Authorization Request (JAR) [RFC9101].
+/// The Authorization Request follows the definition given in [RFC6749].
+/// 
+/// The Verifier may send an Authorization Request as Request Object by value or
+/// by reference as defined in JWT-Secured Authorization Request (JAR) [RFC9101].
 ///
 /// [RFC6749]: (https://www.rfc-editor.org/rfc/rfc6749.html)
 /// [RFC9101]:https://www.rfc-editor.org/rfc/rfc9101
@@ -376,9 +377,10 @@ impl RequestObject {
 }
 
 /// The Request Object Request is used (indirectly) by the Wallet to retrieve a previously
-/// generated Authorization Request Object. The Wallet is sent a `request_uri` containing a
-/// unique URL pointing to the Request Object. The URI has the form
-/// `client_id/request/state_key`.
+/// generated Authorization Request Object.
+/// 
+/// The Wallet is sent a `request_uri` containing a unique URL pointing to the
+/// Request Object. The URI has the form `client_id/request/state_key`.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RequestObjectRequest {
@@ -567,6 +569,7 @@ pub struct MetadataResponse {
 
 /// Used to define the format and proof types of Verifiable Presentations and
 /// Verifiable Credentials that a Verifier supports.
+/// 
 /// Deployments can extend the formats supported, provided Issuers, Holders and
 /// Verifiers all understand the new format.
 /// See <https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#alternative_credential_formats>

--- a/crates/w3c-vc/src/model/vc.rs
+++ b/crates/w3c-vc/src/model/vc.rs
@@ -172,9 +172,11 @@ pub struct CredentialStatus {
 }
 
 /// `CredentialSchema` defines the structure of the credential and the datatypes
-/// of each property contained. It can be used to verify if credential data is
-/// syntatically correct. The precise contents of each data schema is determined
-/// by the specific type definition.
+/// of each property contained.
+/// 
+/// It can be used to verify if credential data is syntatically correct. The
+/// precise contents of each data schema is determined by the specific type
+/// definition.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct CredentialSchema {
@@ -202,6 +204,7 @@ pub struct RefreshService {
 }
 
 /// Term is a single term used in defining the issuers terms of use.
+/// 
 /// In aggregate, the termsOfUse property tells the verifier what actions it is
 /// required to perform (an obligation), not allowed to perform (a prohibition),
 /// or allowed to perform (a permission) if it is to accept the verifiable
@@ -252,9 +255,10 @@ pub struct Policy {
 }
 
 /// Evidence can be included by an issuer to provide the verifier with
-/// additional supporting information in a credential. This could be used by the
-/// verifier to establish the confidence with which it relies on credential
-/// claims.
+/// additional supporting information in a credential.
+/// 
+/// This could be used by the verifier to establish the confidence with which it
+/// relies on credential claims.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct Evidence {

--- a/crates/w3c-vc/src/proof/integrity.rs
+++ b/crates/w3c-vc/src/proof/integrity.rs
@@ -50,8 +50,12 @@ use serde::{Deserialize, Serialize};
 use vercre_core::Quota;
 
 /// To be verifiable, a credential must contain at least one proof mechanism,
-/// and details necessary to evaluate that proof. A proof may be external — an
-/// enveloping proof — or internal — an embedded proof.
+/// and details necessary to evaluate that proof.
+/// 
+/// A proof may be external
+/// 
+///     — an enveloping proof
+///     — or internal — an embedded proof.
 ///
 /// Enveloping proofs are implemented using JOSE and COSE, while embedded proofs
 /// are implemented using the `Proof` object described here.

--- a/vercre-holder/src/provider.rs
+++ b/vercre-holder/src/provider.rs
@@ -30,7 +30,9 @@ pub trait HolderProvider:
 }
 
 /// This provider allows the wallet to interact with an issuer's services that are compliant with
-/// OpenID for VC Issuance. While the specification is oriented towards HTTP, the trait allows the
+/// OpenID for VC Issuance.
+/// 
+/// While the specification is oriented towards HTTP, the trait allows the
 /// wallet (and issuance services) to be transport layer agnostic.
 #[allow(clippy::module_name_repetitions)]
 pub trait Issuer {
@@ -56,8 +58,10 @@ pub trait Issuer {
     ) -> impl Future<Output = anyhow::Result<Logo>> + Send;
 }
 
-/// This provider allows the wallet to interact with a verifier's services that are compliant with
-/// OpenID for Verifiable Presentations. While the specification is oriented towards HTTP, the trait
+/// Allows the wallet to interact with a verifier's services that are compliant with
+/// OpenID for Verifiable Presentations.
+/// 
+/// While the specification is oriented towards HTTP, the trait
 /// allows the wallet (and verifier's services) to be transport layer agnostic.
 pub trait Verifier {
     /// Get a request object. If an error is returned, the wallet will cancel the presentation flow.


### PR DESCRIPTION
Update to clippy is more pedantic about length of initial doc comment for a scope. In most cases the simple fix is to just add a blank line between the first sentence and the rest of the comment so that no documentation is lost. In a couple of cases, the doc comment was not quite correct and has been tidied up.