### PR TITLE
vercre-holder credential responses

### DIFF
--- a/examples/wallet/src-tauri/src/provider/issuer_client.rs
+++ b/examples/wallet/src-tauri/src/provider/issuer_client.rs
@@ -3,9 +3,9 @@ use http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use tauri_plugin_http::reqwest;
 use vercre_holder::provider::Issuer;
 use vercre_holder::{
-    AuthorizationRequest, AuthorizationResponse, CredentialRequest, CredentialResponse, Logo,
-    MetadataRequest, MetadataResponse, OAuthServerRequest, OAuthServerResponse, TokenRequest,
-    TokenResponse,
+    AuthorizationRequest, AuthorizationResponse, CredentialRequest, CredentialResponse,
+    DeferredCredentialRequest, DeferredCredentialResponse, Logo, MetadataRequest, MetadataResponse,
+    OAuthServerRequest, OAuthServerResponse, TokenRequest, TokenResponse,
 };
 
 use super::Provider;
@@ -78,6 +78,13 @@ impl Issuer for Provider {
             .await?;
         let cred = result.json::<CredentialResponse>().await?;
         Ok(cred)
+    }
+
+    /// Get a deferred credential. Not implemented for this example.
+    async fn deferred(
+        &self, _req: DeferredCredentialRequest,
+    ) -> anyhow::Result<DeferredCredentialResponse> {
+        unimplemented!()
     }
 
     /// Get a base64 encoded form of the credential logo.

--- a/vercre-holder/README.md
+++ b/vercre-holder/README.md
@@ -18,3 +18,7 @@ No wallet technology or interactions are mandated by this crate, leaving a
 user-interface or service implementation up to the user. However, see the
 [Example Wallet](https://github.com/vercre/vercre/examples/wallet) for a simple,
 naive implementation using this crate.
+
+The example wallet assumes an issuer-initiated, pre-authorized flow. For
+examples of other possible flows see the `tests` directory for a set of
+end-to-end tests that demonstrate the various flows and interactions.

--- a/vercre-holder/README.md
+++ b/vercre-holder/README.md
@@ -1,44 +1,20 @@
-# Wallet
+# Credential Holder Agent
 
-The Vercre wallet is a cross-platform app with a Rust core and native UI integrated
-using Mozilla's Foreign Function Interface (FFI) library,
-[UniFFI](https://mozilla.github.io/uniffi-rs).
+The Vercre holder agent (typically a wallet) provides an opiniated API for
+managing the receipt of credentials via the OpenID for Verifiable Credentials
+(OIDC4VC) protocol and the presentation of credentials via the OpenID for
+Verifiable Presentation (VP) protocol.
 
-This library contains the wallet's core business logic and FFI bindings. Developers can
-use it to build their own UIs in Swift, Kotlin, or TypeScript. Alternatively, simply
-clone the [Vercre Wallet](<https://github.com/vercre/vercre/vercre-wallet/examples/app>) for a quicker start.
-
-## Cross-platform with Crux
-
-Vercre uses [Crux](<https://redbadger.github.io/crux/overview.html>) with its built-in
-FFI support to simplify the creation of wallets.
-
-Crux splits the application into a **Core** built in Rust (this library), containing the
-business logic, and a **Shell**, or UI, built in the platform native language (Swift,
-Kotlin, TypeScript), that provides the interface with the external world.
-
-The **Core : Shell** interface is a Foreign Function Interface (FFI) where simple
-data structures are passed both ways between the Rust **Core** and [Swift|Kotlin|Typescript]
-**Shell**.
-
-[Learn how to use Crux in your project](https://redbadger.github.io/crux).
+It covers most of the possible flows and interaction types defined in the
+specification and the intention is to be up-to-date with the respective
+`vercre-issuer` and `vercre-verifier` endpoints. There may be some use cases
+that are not covered but in general this crate should be a good starting point
+for anyone needing to implement a custom solution by calling standards-compliant
+issuer and verifier services.
 
 ## Getting Started
 
-For an example of the library used as a Tauri application, see the [Vercre App](<https://github.com/vercre/vercre/vercre-wallet/examples/app>).
-
-For an exmaple of the library published as a WebAssembly package and used as a web application, see the [Vercre Web App](<https://github.com/vercre/vercre/vercre-wallet/examples/web>)
-
-## NPM Packages
-
-The wallet is built as a WebAssembly package and published to NPM. To use it in your typescript project, use your favourite package manager to install it:
-
-```bash
-npm i --save @vercre/vercre-wallet
-```
-
-If using TypeScript you will also need to install some shared types that have been generated from the Rust crux application. These provide classes with serialization and deserialization compatibile with the FFI.
-
-```bash
-npm i --save @vercre/shared-types
-```
+No wallet technology or interactions are mandated by this crate, leaving a
+user-interface or service implementation up to the user. However, see the
+[Example Wallet](https://github.com/vercre/vercre/examples/wallet) for a simple,
+naive implementation using this crate.

--- a/vercre-holder/src/issuance.rs
+++ b/vercre-holder/src/issuance.rs
@@ -16,7 +16,7 @@ use std::fmt::Debug;
 pub use accept::{accept, AcceptRequest, AuthorizationSpec};
 pub use authorize::{authorize, AuthorizeRequest, Initiator};
 pub use cancel::cancel;
-pub use credentials::{credentials, CredentialsRequest};
+pub use credentials::{credentials, CredentialsRequest, CredentialsResponse};
 pub use offer::{offer, OfferRequest, OfferResponse};
 pub use pin::{pin, PinRequest};
 use serde::{Deserialize, Serialize};

--- a/vercre-holder/src/issuance.rs
+++ b/vercre-holder/src/issuance.rs
@@ -7,16 +7,19 @@ pub(crate) mod accept;
 pub(crate) mod authorize;
 pub(crate) mod cancel;
 pub(crate) mod credentials;
+pub(crate) mod deferred;
 pub(crate) mod offer;
 pub(crate) mod pin;
 pub(crate) mod token;
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 pub use accept::{accept, AcceptRequest, AuthorizationSpec};
 pub use authorize::{authorize, AuthorizeRequest, Initiator};
 pub use cancel::cancel;
 pub use credentials::{credentials, CredentialsRequest, CredentialsResponse};
+pub use deferred::{deferred, DeferredRequest};
 pub use offer::{offer, OfferRequest, OfferResponse};
 pub use pin::{pin, PinRequest};
 use serde::{Deserialize, Serialize};
@@ -75,6 +78,10 @@ pub struct Issuance {
 
     /// Requested scope for scope-based authorization.
     pub scope: Option<String>,
+
+    /// Outstanding deferred credential transaction IDs (key) and corresponding
+    /// credential configuration IDs (value).
+    pub deferred: Option<HashMap<String, String>>,
 }
 
 /// Helper functions for using issuance state.
@@ -113,8 +120,7 @@ impl Issuance {
             credential_issuer: credential_issuer.into(),
             issuer: None,
         };
-        let auth_md_response =
-            IssuerProvider::oauth_server(provider, auth_md_request).await?;
+        let auth_md_response = IssuerProvider::oauth_server(provider, auth_md_request).await?;
         self.authorization_server = auth_md_response.authorization_server;
         Ok(())
     }

--- a/vercre-holder/src/issuance/authorize.rs
+++ b/vercre-holder/src/issuance/authorize.rs
@@ -147,13 +147,10 @@ pub async fn authorize(
             // Create a new issuance flow.
             let mut issuance = Issuance::new(client_id);
             issuance.subject_id.clone_from(subject_id);
-            match issuance.set_issuer(&provider, issuer).await {
-                Ok(()) => (),
-                Err(e) => {
-                    tracing::error!(target: "Endpoint::authorize", ?e);
-                    return Err(e);
-                }
-            };
+            issuance.set_issuer(&provider, issuer).await.map_err(|e| {
+                tracing::error!(target: "Endpoint::authorize", ?e);
+                e
+            })?;
             issuance.scope.clone_from(scope);
             issuance
         }
@@ -166,32 +163,24 @@ pub async fn authorize(
     issuance.code_verifier = Some(verifier);
 
     // Construct an authorization request.
-    let authorization_request = match authorization_request(&issuance, request) {
-        Ok(auth_request) => auth_request,
-        Err(e) => {
-            tracing::error!(target: "Endpoint::authorize", ?e);
-            return Err(e);
-        }
-    };
+    let authorization_request = authorization_request(&issuance, request).map_err(|e| {
+        tracing::error!(target: "Endpoint::authorize", ?e);
+        e
+    })?;
     // Request authorization from the issuer.
-    let auth_response = match Issuer::authorization(&provider, authorization_request).await {
-        Ok(auth) => auth,
-        Err(e) => {
+    let auth_response =
+        Issuer::authorization(&provider, authorization_request).await.map_err(|e| {
             tracing::error!(target: "Endpoint::authorize", ?e);
-            return Err(e);
-        }
-    };
+            e
+        })?;
 
     // Construct a token request using the authorization response and request an
     // access token from the issuer.
     let token_request = token_request(&issuance, request, &auth_response);
-    issuance.token = match Issuer::token(&provider, token_request).await {
-        Ok(token) => token,
-        Err(e) => {
-            tracing::error!(target: "Endpoint::authorize", ?e);
-            return Err(e);
-        }
-    };
+    issuance.token = Issuer::token(&provider, token_request).await.map_err(|e| {
+        tracing::error!(target: "Endpoint::authorize", ?e);
+        e
+    })?;
     issuance.status = Status::TokenReceived;
 
     let mut response = AuthorizedCredentials {
@@ -201,13 +190,10 @@ pub async fn authorize(
     if let Some(auth_details) = issuance.token.authorization_details.clone() {
         if !auth_details.is_empty() {
             // Get the authorized credentials.
-            let authorized = match authorized_credentials(&auth_details, &issuance) {
-                Ok(authorized) => authorized,
-                Err(e) => {
-                    tracing::error!(target: "Endpoint::token", ?e);
-                    return Err(e);
-                }
-            };
+            let authorized = authorized_credentials(&auth_details, &issuance).map_err(|e| {
+                tracing::error!(target: "Endpoint::token", ?e);
+                e
+            })?;
             response.authorized = Some(authorized);
         }
     }
@@ -255,15 +241,10 @@ fn authorization_request(
     // to explicitly build the authorization details.
     let auth_details = match scope {
         Some(_) => None,
-        None => {
-            match authorization_details(issuance, request) {
-                Ok(auth_details) => Some(auth_details),
-                Err(e) => {
-                    tracing::error!(target: "Endpoint::authorize", ?e);
-                    return Err(e);
-                }
-            }
-        }
+        None => Some(authorization_details(issuance, request).map_err(|e| {
+            tracing::error!(target: "Endpoint::authorize", ?e);
+            e
+        })?),
     };
 
     let Some(code_challenge_methods) =

--- a/vercre-holder/src/issuance/cancel.rs
+++ b/vercre-holder/src/issuance/cancel.rs
@@ -16,13 +16,10 @@ use crate::provider::{HolderProvider, StateStore};
 pub async fn cancel(provider: impl HolderProvider, issuance_id: &str) -> anyhow::Result<String> {
     tracing::debug!("Endpoint::cancel");
 
-    let issuance: Issuance = match StateStore::get(&provider, issuance_id).await {
-        Ok(issuance) => issuance,
-        Err(e) => {
-            tracing::error!(target: "Endpoint::cancel", ?e);
-            return Err(e);
-        }
-    };
+    let issuance: Issuance = StateStore::get(&provider, issuance_id).await.map_err(|e| {
+        tracing::error!(target: "Endpoint::cancel", ?e);
+        e
+    })?;
 
     // TODO: Issuer notification endpoint.
 

--- a/vercre-holder/src/issuance/deferred.rs
+++ b/vercre-holder/src/issuance/deferred.rs
@@ -1,0 +1,109 @@
+//! # Deferred Credentials Endpoint
+//!
+//! Use a previously issued transaction ID to retrieve a credential.
+
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+use vercre_issuer::{CredentialResponseType, DeferredCredentialRequest};
+
+use super::{Issuance, Status};
+use crate::issuance::credentials::{process_credential_response, CredentialsResponse};
+use crate::provider::{HolderProvider, Issuer, StateStore};
+
+/// Deferred credential request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::module_name_repetitions)]
+pub struct DeferredRequest {
+    /// Issuance flow identifier.
+    pub issuance_id: String,
+
+    /// Transaction ID of the deferred credential.
+    pub transaction_id: String,
+
+    /// Credential configuration ID for the deferred credential.
+    pub credential_configuration_id: String,
+}
+
+/// Progresses the issuance flow by requesting a credential where a previous
+/// transaction ID was issued in lieu of a credential.
+///
+/// Returns the issuance flow identifier and a deferred transaction ID if the
+/// credential is not yet available.
+#[instrument(level = "debug", skip(provider))]
+pub async fn deferred(
+    provider: impl HolderProvider, request: &DeferredRequest,
+) -> anyhow::Result<CredentialsResponse> {
+    tracing::debug!("Endpoint::credentials {:?}", request);
+
+    let mut issuance: Issuance =
+        StateStore::get(&provider, &request.issuance_id).await.map_err(|e| {
+            tracing::error!(target: "Endpoint::deferred", ?e);
+            e
+        })?;
+    if issuance.status != Status::TokenReceived {
+        let e = anyhow!("invalid issuance state");
+        tracing::error!(target: "Endpoint::deferred", ?e);
+        return Err(e);
+    }
+
+    let mut deferred = issuance.deferred.unwrap_or_default();
+    deferred.remove(&request.transaction_id);
+
+    let def_cred_request = DeferredCredentialRequest {
+        transaction_id: request.transaction_id.clone(),
+        credential_issuer: issuance.issuer.credential_issuer.clone(),
+        access_token: issuance.token.access_token.clone(),
+    };
+    let deferred_response = Issuer::deferred(&provider, def_cred_request).await.map_err(|e| {
+        tracing::error!(target: "Endpoint::deferred", ?e);
+        e
+    })?;
+
+    let Some(config) = issuance
+        .issuer
+        .credential_configurations_supported
+        .get(&request.credential_configuration_id)
+    else {
+        let e = anyhow!("credential configuration not found in issuer metadata");
+        tracing::error!(target: "Endpoint::deferred", ?e);
+        return Err(e);
+    };
+
+    match process_credential_response(
+        provider.clone(),
+        config,
+        &deferred_response.credential_response,
+    )
+    .await
+    {
+        Ok(()) => {
+            if let CredentialResponseType::TransactionId(id) =
+                &deferred_response.credential_response.response
+            {
+                deferred.insert(id.clone(), request.credential_configuration_id.clone());
+            }
+        }
+        Err(e) => {
+            tracing::error!(target: "Endpoint::deferred", ?e);
+            return Err(e);
+        }
+    };
+
+    // Release issuance state if no more deferred credentials.
+    let deferred = if deferred.is_empty() {
+        StateStore::purge(&provider, &issuance.id).await.map_err(|e| {
+            tracing::error!(target: "Endpoint::credentials", ?e);
+            anyhow!("issue purging state: {e}")
+        })?;
+        None
+    } else {
+        issuance.deferred = Some(deferred.clone());
+        Some(deferred)
+    };
+
+    Ok(CredentialsResponse {
+        issuance_id: issuance.id,
+        deferred,
+    })
+}

--- a/vercre-holder/src/issuance/offer.rs
+++ b/vercre-holder/src/issuance/offer.rs
@@ -90,13 +90,10 @@ pub async fn offer(
 
     // Set up a credential configuration for each credential offered.
     issuance.offer = request.offer.clone();
-    match issuance.set_issuer(&provider, &request.offer.credential_issuer).await {
-        Ok(()) => (),
-        Err(e) => {
-            tracing::error!(target: "Endpoint::offer", ?e);
-            return Err(e);
-        }
-    };
+    issuance.set_issuer(&provider, &request.offer.credential_issuer).await.map_err(|e| {
+        tracing::error!(target: "Endpoint::offer", ?e);
+        e
+    })?;
     issuance.status = Status::Ready;
 
     // Stash the state for the next step.

--- a/vercre-holder/src/issuance/pin.rs
+++ b/vercre-holder/src/issuance/pin.rs
@@ -31,13 +31,11 @@ pub struct PinRequest {
 pub async fn pin(provider: impl HolderProvider, request: &PinRequest) -> anyhow::Result<String> {
     tracing::debug!("Endpoint::pin");
 
-    let mut issuance: Issuance = match StateStore::get(&provider, &request.issuance_id).await {
-        Ok(issuance) => issuance,
-        Err(e) => {
+    let mut issuance: Issuance =
+        StateStore::get(&provider, &request.issuance_id).await.map_err(|e| {
             tracing::error!(target: "Endpoint::pin", ?e);
-            return Err(e);
-        }
-    };
+            e
+        })?;
     if issuance.status != Status::PendingPin {
         let e = anyhow!("invalid issuance state");
         tracing::error!(target: "Endpoint::pin", ?e);

--- a/vercre-holder/src/lib.rs
+++ b/vercre-holder/src/lib.rs
@@ -50,6 +50,7 @@ pub use vercre_openid::issuer::{
     AuthorizationCodeGrant, AuthorizationDetail, AuthorizationDetailType, AuthorizationRequest,
     AuthorizationResponse, Claim, ClaimDefinition, CredentialAuthorization,
     CredentialConfiguration, CredentialOffer, CredentialRequest, CredentialResponse,
+    CredentialResponseType, DeferredCredentialRequest, DeferredCredentialResponse,
     FormatIdentifier, Grants, Issuer, MetadataRequest, MetadataResponse, OAuthServerRequest,
     OAuthServerResponse, PreAuthorizedCodeGrant, ProfileClaims, Proof, ProofClaims, TokenRequest,
     TokenResponse, TxCode,

--- a/vercre-holder/src/provider.rs
+++ b/vercre-holder/src/provider.rs
@@ -13,7 +13,8 @@ pub use vercre_did::{DidResolver, Document};
 pub use vercre_dif_exch::Constraints;
 pub use vercre_issuer::{
     AuthorizationRequest, AuthorizationResponse, CredentialRequest, CredentialResponse,
-    MetadataRequest, OAuthServerRequest, OAuthServerResponse, MetadataResponse, TokenRequest, TokenResponse, TxCode,
+    DeferredCredentialRequest, DeferredCredentialResponse, MetadataRequest, MetadataResponse,
+    OAuthServerRequest, OAuthServerResponse, TokenRequest, TokenResponse, TxCode,
 };
 pub use vercre_openid::provider::{Result, StateStore};
 use vercre_openid::verifier::{RequestObjectResponse, ResponseRequest, ResponseResponse};
@@ -35,38 +36,37 @@ pub trait HolderProvider:
 /// wallet (and issuance services) to be transport layer agnostic.
 #[allow(clippy::module_name_repetitions)]
 pub trait Issuer {
-    /// Get issuer metadata. If an error is returned, the wallet will cancel the
-    /// issuance flow.
+    /// Get issuer metadata.
     fn metadata(
         &self, req: MetadataRequest,
     ) -> impl Future<Output = anyhow::Result<MetadataResponse>> + Send;
 
-    /// Get OAuth authorization configuration. If an error is returned, the
-    /// wallet will cancel the issuance flow.
+    /// Get OAuth authorization configuration.
     fn oauth_server(
         &self, req: OAuthServerRequest,
     ) -> impl Future<Output = anyhow::Result<OAuthServerResponse>> + Send;
 
-    /// Get an authorization code. If an error is returned, the wallet will
-    /// cancel the issuance flow.
+    /// Get an authorization code.
     fn authorization(
         &self, req: AuthorizationRequest,
     ) -> impl Future<Output = anyhow::Result<AuthorizationResponse>> + Send;
 
-    /// Get an access token. If an error is returned, the wallet will cancel the
-    /// issuance flow.
+    /// Get an access token.
     fn token(
         &self, req: TokenRequest,
     ) -> impl Future<Output = anyhow::Result<TokenResponse>> + Send;
 
-    /// Get a credential. If an error is returned, the wallet will cancel the
-    /// issuance flow.
+    /// Get a credential.
     fn credential(
         &self, req: CredentialRequest,
     ) -> impl Future<Output = anyhow::Result<CredentialResponse>> + Send;
 
-    /// Get a base64 encoded form of the credential logo. If an error is
-    /// returned the wallet library will ignore.
+    /// Get a deferred credential.
+    fn deferred(
+        &self, req: DeferredCredentialRequest,
+    ) -> impl Future<Output = anyhow::Result<DeferredCredentialResponse>> + Send;
+
+    /// Get a base64 encoded form of the credential logo.
     fn logo(&self, logo_url: &str) -> impl Future<Output = anyhow::Result<Logo>> + Send;
 }
 

--- a/vercre-holder/tests/preauth_deferred.rs
+++ b/vercre-holder/tests/preauth_deferred.rs
@@ -1,0 +1,94 @@
+//! Tests for issuer-initiated pre-authorized issuance flow where the holder
+//! accepts all credentials and all claims on offer but the issuance is
+//! deferred.
+
+mod provider;
+
+use std::sync::LazyLock;
+
+use insta::assert_yaml_snapshot as assert_snapshot;
+use vercre_holder::issuance::{AcceptRequest, CredentialsRequest, OfferRequest, PinRequest};
+use vercre_issuer::{OfferType, SendType};
+use vercre_macros::create_offer_request;
+use vercre_test_utils::issuer::{self, CLIENT_ID, CREDENTIAL_ISSUER, PENDING_USER};
+
+use crate::provider as holder;
+
+static ISSUER_PROVIDER: LazyLock<issuer::Provider> = LazyLock::new(issuer::Provider::new);
+static HOLDER_PROVIDER: LazyLock<holder::Provider> =
+    LazyLock::new(|| holder::Provider::new(Some(ISSUER_PROVIDER.clone()), None));
+
+// Test end-to-end pre-authorized issuance flow, with acceptance of all
+// credentials on offer, but where the issuance is deferred.
+#[tokio::test]
+async fn preauth_deferred() {
+    // Use the issuance service endpoint to create a sample offer so we can get a
+    // valid pre-authorized code.
+    let request = create_offer_request!({
+        "credential_issuer": CREDENTIAL_ISSUER,
+        "credential_configuration_ids": ["EmployeeID_JWT"],
+        "subject_id": PENDING_USER,
+        "pre-authorize": true,
+        "tx_code_required": true,
+        "send_type": SendType::ByVal,
+    });
+
+    let offer_resp = vercre_issuer::create_offer(ISSUER_PROVIDER.clone(), request)
+        .await
+        .expect("should get offer");
+
+    let OfferType::Object(offer) = offer_resp.offer_type else {
+        panic!("expected CredentialOfferType::Object");
+    };
+
+    // Initiate the pre-authorized code flow
+    let offer_req = OfferRequest {
+        client_id: CLIENT_ID.into(),
+        subject_id: PENDING_USER.into(),
+        offer,
+    };
+    let issuance = vercre_holder::issuance::offer(HOLDER_PROVIDER.clone(), &offer_req)
+        .await
+        .expect("should process offer");
+
+    assert_snapshot!("created", issuance, {
+        ".issuance_id" => "[issuance_id]",
+        ".grants[\"urn:ietf:params:oauth:grant-type:pre-authorized_code\"][\"pre-authorized_code\"]" => "[pre-authorized_code]",
+        ".**.credentialSubject" => insta::sorted_redaction(),
+        ".**.credentialSubject.address" => insta::sorted_redaction(),
+    });
+
+    // Accept all credentials on offer
+    let accept_req = AcceptRequest {
+        issuance_id: issuance.issuance_id.clone(),
+        accept: None,
+    };
+    vercre_holder::issuance::accept(HOLDER_PROVIDER.clone(), &accept_req)
+        .await
+        .expect("should accept offer");
+
+    // Enter PIN
+    let pin_req = PinRequest {
+        issuance_id: issuance.issuance_id.clone(),
+        pin: offer_resp.tx_code.expect("should have user code"),
+    };
+    vercre_holder::issuance::pin(HOLDER_PROVIDER.clone(), &pin_req)
+        .await
+        .expect("should apply pin");
+
+    // Get available credential identifiers.
+    vercre_holder::issuance::token(HOLDER_PROVIDER.clone(), &issuance.issuance_id)
+        .await
+        .expect("should get token");
+
+    // Get (and store) credentials. Accept all on offer.
+    let cred_req = CredentialsRequest {
+        issuance_id: issuance.issuance_id.clone(),
+        ..Default::default()
+    };
+    let response = vercre_holder::issuance::credentials(HOLDER_PROVIDER.clone(), &cred_req)
+        .await
+        .expect("should get credentials");
+
+    assert!(response.deferred.is_some());
+}

--- a/vercre-holder/tests/provider.rs
+++ b/vercre-holder/tests/provider.rs
@@ -15,9 +15,9 @@ use vercre_holder::provider::{
 };
 use vercre_holder::{
     AuthorizationRequest, AuthorizationResponse, Credential, CredentialRequest, CredentialResponse,
-    Logo, MetadataRequest, MetadataResponse, OAuthServerRequest, OAuthServerResponse,
-    RequestObjectRequest, RequestObjectResponse, ResponseRequest, ResponseResponse, TokenRequest,
-    TokenResponse,
+    DeferredCredentialRequest, DeferredCredentialResponse, Logo, MetadataRequest, MetadataResponse,
+    OAuthServerRequest, OAuthServerResponse, RequestObjectRequest, RequestObjectResponse,
+    ResponseRequest, ResponseResponse, TokenRequest, TokenResponse,
 };
 use vercre_test_utils::store::keystore::HolderKeystore;
 use vercre_test_utils::store::{resolver, state};
@@ -72,6 +72,13 @@ impl Issuer for Provider {
 
     async fn credential(&self, req: CredentialRequest) -> anyhow::Result<CredentialResponse> {
         let response = vercre_issuer::credential(self.issuer.clone().unwrap(), req).await?;
+        Ok(response)
+    }
+
+    async fn deferred(
+        &self, req: DeferredCredentialRequest,
+    ) -> anyhow::Result<DeferredCredentialResponse> {
+        let response = vercre_issuer::deferred(self.issuer.clone().unwrap(), req).await?;
         Ok(response)
     }
 

--- a/vercre-holder/tests/snapshots/preauth_deferred__created.snap
+++ b/vercre-holder/tests/snapshots/preauth_deferred__created.snap
@@ -1,0 +1,85 @@
+---
+source: vercre-holder/tests/preauth_deferred.rs
+assertion_line: 55
+expression: issuance
+---
+issuance_id: "[issuance_id]"
+issuer: "http://vercre.io"
+offered:
+  EmployeeID_JWT:
+    format: jwt_vc_json
+    credential_definition:
+      type:
+        - VerifiableCredential
+        - EmployeeIDCredential
+      credentialSubject:
+        address:
+          country:
+            value_type: string
+            display:
+              - name: Country
+                locale: en-NZ
+          locality:
+            value_type: string
+            display:
+              - name: Locality
+                locale: en-NZ
+          region:
+            value_type: string
+            display:
+              - name: Region
+                locale: en-NZ
+          street_address:
+            value_type: string
+            display:
+              - name: Street Address
+                locale: en-NZ
+        email:
+          mandatory: true
+          value_type: string
+          display:
+            - name: Email
+              locale: en-NZ
+        family_name:
+          mandatory: true
+          value_type: string
+          display:
+            - name: Family name
+              locale: en-NZ
+        given_name:
+          mandatory: true
+          value_type: string
+          display:
+            - name: Given name
+              locale: en-NZ
+    scope: EmployeeIDCredential
+    cryptographic_binding_methods_supported:
+      - "did:key"
+      - "did:web"
+    credential_signing_alg_values_supported:
+      - ES256K
+      - EdDSA
+    proof_types_supported:
+      jwt:
+        proof_signing_alg_values_supported:
+          - ES256K
+          - EdDSA
+    display:
+      - name: Employee ID
+        locale: en-NZ
+        logo:
+          uri: "https://vercre.github.io/assets/employee.png"
+          alt_text: Vercre Logo
+        description: Vercre employee ID credential
+        background_color: "#323ed2"
+        background_image:
+          uri: "https://vercre.github.io/assets/vercre-background.png"
+          alt_text: Vercre Background
+        text_color: "#ffffff"
+grants:
+  "urn:ietf:params:oauth:grant-type:pre-authorized_code":
+    pre-authorized_code: "[pre-authorized_code]"
+    tx_code:
+      input_mode: numeric
+      length: 6
+      description: Please provide the one-time code received

--- a/vercre-holder/tests/snapshots/preauth_deferred__credentials.snap
+++ b/vercre-holder/tests/snapshots/preauth_deferred__credentials.snap
@@ -1,0 +1,99 @@
+---
+source: vercre-holder/tests/preauth_deferred.rs
+assertion_line: 113
+expression: credentials
+---
+- id: "http://vercre.io/credentials/EmployeeIDCredential"
+  issuer: "http://vercre.io"
+  vc:
+    "@context":
+      - "https://www.w3.org/2018/credentials/v1"
+      - "http://vercre.io/credentials/v1"
+    credentialSubject:
+      address:
+        locality: Wellington
+        street_address: 123 Fake St
+      email: pending.user@example.com
+      family_name: Person
+      given_name: Pending
+      id: "did:key:z6Mkj8Jr1rg3YjVWWhg7ahEYJibqhjBgZt1pDCbT4Lv7D4HX"
+    id: "http://vercre.io/credentials/EmployeeIDCredential"
+    issuanceDate: "[issuanceDate]"
+    issuer: "http://vercre.io"
+    type:
+      - VerifiableCredential
+      - EmployeeIDCredential
+  metadata:
+    credential_definition:
+      credentialSubject:
+        address:
+          country:
+            value_type: string
+            display:
+              - name: Country
+                locale: en-NZ
+          locality:
+            value_type: string
+            display:
+              - name: Locality
+                locale: en-NZ
+          region:
+            value_type: string
+            display:
+              - name: Region
+                locale: en-NZ
+          street_address:
+            value_type: string
+            display:
+              - name: Street Address
+                locale: en-NZ
+        email:
+          mandatory: true
+          value_type: string
+          display:
+            - name: Email
+              locale: en-NZ
+        family_name:
+          mandatory: true
+          value_type: string
+          display:
+            - name: Family name
+              locale: en-NZ
+        given_name:
+          mandatory: true
+          value_type: string
+          display:
+            - name: Given name
+              locale: en-NZ
+      type:
+        - VerifiableCredential
+        - EmployeeIDCredential
+    credential_signing_alg_values_supported:
+      - ES256K
+      - EdDSA
+    cryptographic_binding_methods_supported:
+      - "did:key"
+      - "did:web"
+    display:
+      - name: Employee ID
+        locale: en-NZ
+        logo:
+          uri: "https://vercre.github.io/assets/employee.png"
+          alt_text: Vercre Logo
+        description: Vercre employee ID credential
+        background_color: "#323ed2"
+        background_image:
+          uri: "https://vercre.github.io/assets/vercre-background.png"
+          alt_text: Vercre Background
+        text_color: "#ffffff"
+    format: jwt_vc_json
+    proof_types_supported:
+      jwt:
+        proof_signing_alg_values_supported:
+          - ES256K
+          - EdDSA
+    scope: EmployeeIDCredential
+  issued: "[issued]"
+  logo:
+    image: ""
+    mediaType: ""


### PR DESCRIPTION
Add ability for the wallet to receive one or multiple credentials from the issuer's credential endpoint, or a transaction ID for a deferred issuance. Add a deferred endpoint for handling the deferred request.